### PR TITLE
chore(deps): update ndarray, rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ csv = "*"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_pcg = "0.3"
 num = "*"
-ndarray = "0.15"
+ndarray = ">=0.16,<0.18"
 bencher = "*"
 ndarray-parallel = { version = "*", optional = true }
 rayon = { version = "*", optional = true }
@@ -34,5 +34,5 @@ path = "src/example.rs"
 
 [[bench]]
 name = "bench"
-path = "src/bench.rs"
+path = "rkm/benches/bench.rs"
 harness = false

--- a/rkm/Cargo.toml
+++ b/rkm/Cargo.toml
@@ -16,11 +16,11 @@ edition = "2018"
 parallel = ["rayon", "ndarray/rayon"]
 
 [dependencies]
-rand = {version = "0.7.3", features = ["small_rng"]}
+rand = {version = "0.8", features = ["small_rng"]}
 num = "0.2.1"
-ndarray = "0.13.0"
+ndarray = ">=0.16,<0.18"
 cfg-if = "0.1.10"
-rayon = {version = "1.3.0", optional = true}
+rayon = {version = "*", optional = true}
 
 [dev-dependencies]
 csv = "1.1.3"

--- a/rkm/benches/bench.rs
+++ b/rkm/benches/bench.rs
@@ -19,12 +19,12 @@ fn read_test_data(data_path: &str, dim: usize) -> Array2<f32> {
 
 fn bench_iris(b: &mut Bencher) {
     let data = read_test_data("data/iris.data.csv", 2);
-    b.iter(|| rkm::kmeans_lloyd(&data.view(), 3));
+    b.iter(|| rkm::kmeans_lloyd(&data.view(), 3, Some(1), None));
 }
 
 fn bench_s1(b: &mut Bencher) {
     let data = read_test_data("data/s1.data.csv", 2);
-    b.iter(|| rkm::kmeans_lloyd(&data.view(), 15));
+    b.iter(|| rkm::kmeans_lloyd(&data.view(), 15, Some(1), None));
 }
 
 // Disabled due to https://github.com/rust-lang/rust/issues/11010
@@ -32,12 +32,12 @@ fn bench_s1(b: &mut Bencher) {
 #[allow(dead_code)]
 fn bench_birch3(b: &mut Bencher) {
     let data = read_test_data("data/birch3.data.csv", 2);
-    b.iter(|| rkm::kmeans_lloyd(&data.view(), 100));
+    b.iter(|| rkm::kmeans_lloyd(&data.view(), 100, Some(1), None));
 }
 
 fn bench_dim128(b: &mut Bencher) {
     let data = read_test_data("data/dim128.data.csv", 128);
-    b.iter(|| rkm::kmeans_lloyd(&data.view(), 16));
+    b.iter(|| rkm::kmeans_lloyd(&data.view(), 16, Some(1), None));
 }
 
 // TODO: bencher uses too high an iteration count for birch3, takes forever to execute


### PR DESCRIPTION
* Bump ndarray and rand

* Fix benches to invoke rkm::kmeans_lloyd correctly

Testing:

```
cargo clean
     Removed 301 files, 26.1MiB total

cargo check --all-targets
   Compiling autocfg v1.4.0
   Compiling libc v0.2.171
   Compiling zerocopy v0.8.23
    Checking cfg-if v1.0.0
   Compiling serde v1.0.219
    Checking memchr v2.7.4
    Checking rawpointer v0.2.1
    Checking ryu v1.0.20
    Checking itoa v1.0.15
    Checking bencher v0.1.5
   Compiling num-traits v0.2.19
   Compiling matrixmultiply v0.3.9
    Checking csv-core v0.1.12
    Checking num-integer v0.1.46
    Checking num-complex v0.4.6
    Checking num-bigint v0.4.6
    Checking num-iter v0.1.45
    Checking ndarray v0.16.1
    Checking getrandom v0.2.15
    Checking rand_core v0.6.4
    Checking rand_pcg v0.3.1
    Checking ppv-lite86 v0.2.21
    Checking num-rational v0.4.2
    Checking rand_chacha v0.3.1
    Checking num v0.4.3
    Checking rand v0.8.5
    Checking csv v1.3.1
    Checking rkm v0.8.1 (/Users/guy.joseph/dev/rkm)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.48s
```